### PR TITLE
pkg: ignore symbol indexing/iterator for ts types.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18.x
+
+    - name: Install dependencies
+      run: npm install --location=global bslint
+
+    - name: Lint
+      run: npm run lint
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18.x
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Test
+      run: npm run test

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -762,8 +762,10 @@ function ownKeys(obj) {
   for (const symbol of symbols) {
     const desc = Object.getOwnPropertyDescriptor(obj, symbol);
 
-    if (desc && desc.enumerable)
+    if (desc && desc.enumerable) {
+      // @ts-ignore
       keys.push(symbol);
+    }
   }
 
   return keys;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "bsert",
+  "version": "0.0.10",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bsert",
+      "version": "0.0.10",
+      "license": "MIT",
+      "devDependencies": {
+        "bmocha": "^2.1.8"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bmocha": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/bmocha/-/bmocha-2.1.8.tgz",
+      "integrity": "sha512-bog23Ckl9lRyBxrsi4FmX1rTz4d1WhHRpIA+q2lpoiXmNuroMHr1JUOU5sPiMZwvhLCxqffvWv3xCJC7PC126w==",
+      "dev": true,
+      "bin": {
+        "_bmocha": "bin/_bmocha",
+        "bmocha": "bin/bmocha"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,10 +14,13 @@
   "author": "Christopher Jeffrey <chjjeffrey@gmail.com>",
   "main": "./lib/assert.js",
   "scripts": {
-    "lint": "eslint lib/ test/ || exit 0",
+    "lint": "eslint lib/ test/",
     "test": "bmocha --reporter spec test/*-test.js"
   },
   "engines": {
     "node": ">=8.0.0"
+  },
+  "devDependencies": {
+    "bmocha": "^2.1.8"
   }
 }


### PR DESCRIPTION
Allow recursive typescript checks from dependants to the bsert to work, allowing us to use typescript as a type linter with jsdoc.